### PR TITLE
fix: modify 'shape' access + memoize 'len' 

### DIFF
--- a/src/core.rs
+++ b/src/core.rs
@@ -19,6 +19,7 @@ where
     pub(crate) shape: [usize; N],
     pub(crate) storage: S,
     _marker: PhantomData<T>,
+    len: usize,
 }
 
 impl<T: Num + Copy, S, const N: usize> Dimensional<T, S, N>
@@ -42,10 +43,12 @@ where
     /// ```
     pub fn zeros(shape: [usize; N]) -> Self {
         let storage = S::zeros(shape);
+        let len = shape.iter().product();
         Self {
             shape,
             storage,
             _marker: PhantomData,
+            len,
         }
     }
 
@@ -66,10 +69,12 @@ where
     /// ```
     pub fn ones(shape: [usize; N]) -> Self {
         let storage = S::ones(shape);
+        let len = shape.iter().product();
         Self {
             shape,
             storage,
             _marker: PhantomData,
+            len,
         }
     }
 
@@ -91,8 +96,9 @@ where
     /// assert_eq!(array.as_slice(), &[1, 2, 3, 4, 5, 6]);
     /// ```
     pub fn new(shape: [usize; N], storage: S) -> Self {
+        let len = shape.iter().product();
         assert_eq!(
-            shape.iter().product::<usize>(),
+            len,
             storage.as_slice().len(),
             "Storage size must match the product of shape dimensions"
         );
@@ -100,6 +106,7 @@ where
             shape,
             storage,
             _marker: PhantomData,
+            len,
         }
     }
 
@@ -124,12 +131,14 @@ where
     where
         F: Fn([usize; N]) -> T,
     {
+        let len = shape.iter().product();
         let data = (0..shape.iter().product::<usize>())
             .map(|i| {
                 let temp = Self {
                     shape,
                     storage: S::zeros(shape), // Temporary storage
                     _marker: PhantomData,
+                    len,
                 };
                 let index = temp.unravel_index(i);
                 f(index)
@@ -141,10 +150,9 @@ where
             shape,
             storage,
             _marker: PhantomData,
+            len,
         }
     }
-
-    // TODO Seems like both of these could just use the shape already on the object
 
     /// Converts a linear index to a multidimensional index.
     ///
@@ -203,15 +211,13 @@ where
         N
     }
 
-    // TODO seems like this could me memoized
-
     /// Returns the total number of elements in the array.
     ///
     /// # Returns
     ///
     /// The total number of elements as `usize`.
     pub fn len(&self) -> usize {
-        self.shape.iter().product()
+        self.len
     }
 
     /// Returns `true` if the array is empty.

--- a/src/display.rs
+++ b/src/display.rs
@@ -83,7 +83,7 @@ where
                 let mut index_array = [0; N];
                 index_array[0] = i;
                 index_array[1] = j;
-                let index = Self::ravel_index(&index_array, &shape);
+                let index = self.ravel_index(&index_array);
                 // Check if a precision is specified in the formatter
                 if let Some(precision) = f.precision() {
                     write!(f, "{:.1$}", self.as_slice()[index], precision)?;

--- a/src/iterators.rs
+++ b/src/iterators.rs
@@ -107,7 +107,7 @@ where
 
         self.remaining -= 1;
 
-        let linear_index = Dimensional::<T, S, N>::ravel_index(&index, &self.dimensional.shape());
+        let linear_index = self.dimensional.ravel_index(&index);
         // TODO: We really don't want to use unsafe rust here
         // SAFETY: This is safe because we're returning a unique reference to each element,
         // and we're iterating over each element only once.


### PR DESCRIPTION
Pretty straightforward, using the shape already on the object for unravel_index and ravel_index (self.shape instead of taking a shape parameter)