### PR TITLE
Fix shape access

### DIFF
--- a/benches/benchmarks.rs
+++ b/benches/benchmarks.rs
@@ -54,27 +54,21 @@ fn bench_matrix_multiplication(c: &mut Criterion) {
     let m1 = Dimensional::<f64, LinearArrayStorage<f64, 2>, 2>::ones(shape1);
     let m2 = Dimensional::<f64, LinearArrayStorage<f64, 2>, 2>::ones(shape2);
 
-    c.bench_function("matrix_multiplication", |b| {
-        b.iter(|| m1.dot(&m2))
-    });
+    c.bench_function("matrix_multiplication", |b| b.iter(|| m1.dot(&m2)));
 }
 
 fn bench_matrix_transpose(c: &mut Criterion) {
     let shape = [1000, 1000];
     let m = Dimensional::<f64, LinearArrayStorage<f64, 2>, 2>::ones(shape);
 
-    c.bench_function("matrix_transpose", |b| {
-        b.iter(|| m.transpose())
-    });
+    c.bench_function("matrix_transpose", |b| b.iter(|| m.transpose()));
 }
 
 fn bench_matrix_trace(c: &mut Criterion) {
     let shape = [1000, 1000];
     let m = Dimensional::<f64, LinearArrayStorage<f64, 2>, 2>::ones(shape);
 
-    c.bench_function("matrix_trace", |b| {
-        b.iter(|| m.trace())
-    });
+    c.bench_function("matrix_trace", |b| b.iter(|| m.trace()));
 }
 
 criterion_group!(

--- a/src/display.rs
+++ b/src/display.rs
@@ -83,7 +83,7 @@ where
                 let mut index_array = [0; N];
                 index_array[0] = i;
                 index_array[1] = j;
-                let index = Self::ravel_index(&index_array, &shape);
+                let index = self.ravel_index(&index_array);
                 // Check if a precision is specified in the formatter
                 if let Some(precision) = f.precision() {
                     write!(f, "{:.1$}", self.as_slice()[index], precision)?;
@@ -262,5 +262,15 @@ mod tests {
             format!("{}", array_5d),
             "5D array: shape [2, 2, 2, 2, 2], data [0, 1, 2, ..., 31]"
         );
+    }
+
+    #[test]
+    fn test_display_consistency() {
+        let array: Dimensional<i32, LinearArrayStorage<i32, 2>, 2> =
+            Dimensional::from_fn([3, 4], |[i, j]| (i * 4 + j) as i32);
+
+        let display_output = format!("{}", array);
+        let expected_output = "[\n [0, 1, 2, 3],\n [4, 5, 6, 7],\n [8, 9, 10, 11]\n]";
+        assert_eq!(display_output, expected_output, "Display output mismatch");
     }
 }

--- a/src/iterators.rs
+++ b/src/iterators.rs
@@ -360,7 +360,7 @@ mod tests {
         let mut iter = array_3d.iter_mut();
         for i in 1..=12 {
             if let Some(elem) = iter.next() {
-                *elem = i as i32;
+                *elem = i;
             }
         }
 

--- a/src/operators.rs
+++ b/src/operators.rs
@@ -222,7 +222,8 @@ where
     /// Multiplies two matrices.
     pub fn dot(&self, rhs: &Self) -> Self {
         assert_eq!(
-            self.shape()[1], rhs.shape()[0],
+            self.shape()[1],
+            rhs.shape()[0],
             "Matrix dimensions must match for multiplication"
         );
         let (rows, cols) = (self.shape()[0], rhs.shape()[1]);
@@ -253,7 +254,11 @@ where
 {
     /// Computes the trace of a matrix.
     pub fn trace(&self) -> T {
-        assert_eq!(self.shape()[0], self.shape()[1], "Matrix must be square to compute trace");
+        assert_eq!(
+            self.shape()[0],
+            self.shape()[1],
+            "Matrix must be square to compute trace"
+        );
         (0..self.shape()[0]).fold(T::zero(), |sum, i| sum + self[[i, i]])
     }
 }
@@ -628,23 +633,13 @@ mod tests {
     #[test]
     fn test_matrix_multiplication() {
         // Define a 2x3 matrix
-        let m1 = matrix![
-            [1, 2, 3],
-            [4, 5, 6]
-        ];
+        let m1 = matrix![[1, 2, 3], [4, 5, 6]];
 
         // Define a 3x2 matrix
-        let m2 = matrix![
-            [7, 8],
-            [9, 10],
-            [11, 12]
-        ];
+        let m2 = matrix![[7, 8], [9, 10], [11, 12]];
 
         // Expected 2x2 product matrix
-        let product = matrix![
-            [58, 64],
-            [139, 154]
-        ];
+        let product = matrix![[58, 64], [139, 154]];
 
         assert_eq!(m1.dot(&m2), product);
     }

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -38,6 +38,11 @@ pub trait DimensionalStorage<T: Num + Copy, const N: usize>:
     /// Returns the total number of elements in the storage.
     fn len(&self) -> usize;
 
+    /// Checks if the storage is empty.
+    fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
     /// Returns a mutable slice of the underlying data from storage.
     fn as_mut_slice(&mut self) -> &mut [T];
 


### PR DESCRIPTION
**core:** f36fe2dbf4d04cbc0763991c287891863c42f2ab
- updated `ravel_index` and `unravel_index` to use `self.shape` instead of the passed `shape` param
- `from_fn` :
    -  create an initial `Dimensional` instance with zeros
    -  iterate through the linear indices of the array
    -  for each linear index, use `unravel_index` to get the corresponding multidimensional index
    -  apply `f` to this multidimensional index and store the result

**display:** f36fe2dbf4d04cbc0763991c287891863c42f2ab
- updated `fmt_2d` to use `shape` correctly

**iterators:** a53bff389c5beeb8e5dff6f036bd46f2c69b9894
- updated `next` to use `shape` correctly
- changed iteration logic:
    - `remaining` value is decremented before updating the `current_index`
    - `current_index` updates in row-major order: starting from the innermost dimension, carrying over to the next dimension when it exceeds bounds
    - for an empty array, the iterator yields `None` because the `remaining` value is already 0